### PR TITLE
Remove Multidex declaration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -126,8 +126,6 @@ dependencies {
     testImplementation(AppDependencies.kotlinCoRoutinesCoreTest)
     testImplementation(AppDependencies.junit)
     testImplementation(AppDependencies.robolectric)
-    testImplementation(AppDependencies.robolectricShadows)
-    testImplementation(AppDependencies.robolectricSupport)
     testImplementation(AppDependencies.archCoreTesting)
     testImplementation(AppDependencies.junitRunner)
     testImplementation(AppDependencies.mockito)

--- a/buildSrc/src/main/kotlin/AppDependencies.kt
+++ b/buildSrc/src/main/kotlin/AppDependencies.kt
@@ -92,9 +92,6 @@ object AppDependencies {
     // Robolectric and Espresso framework
     const val mockk = "io.mockk:mockk:${Versions.mockk}"
     const val robolectric = "org.robolectric:robolectric:${Versions.robolectric}"
-    const val robolectricShadows = "org.robolectric:shadows-multidex:${Versions.robolectricShadows}"
-    const val robolectricSupport =
-        "org.robolectric:shadows-supportv4:${Versions.robolectricShadows}"
     const val espressoIdling =
         "androidx.test.espresso:espresso-idling-resource:${Versions.espresso}"
     const val espressoContrib = "androidx.test.espresso:espresso-contrib:${Versions.espresso}"

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -42,7 +42,6 @@ object Versions {
     const val mockk = "1.13.8"
 
     const val robolectric = "4.5"
-    const val robolectricShadows = "4.5"
     const val kotlinCoroutineTest = "1.4.2"
     const val nhaarmanMockito = "2.2.0"
     const val okHttpMockServer = "4.7.2"


### PR DESCRIPTION
Since the min SDK is 28, it is no longer necessary to use the Multidex library.

See the following for more info: https://developer.android.com/build/multidex#mdex-on-l

-----

This also removes the dependency on Robolectric's `shadows-supportv4` module, since it was removed in Robolectric 4.9.

See the following for more information: https://robolectric.org/using-add-on-modules/#removed-packages